### PR TITLE
Test PHP 5.5, 7.3 and ignore HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ branches:
 matrix:
     fast_finish: true
     include:
+        - php: 7.3
         - php: 7.2
         - php: 7.1
         - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
 
 before_script:
+    - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --dev --no-update; fi;
     - if [ "$PREDIS_VERSION" != "" ]; then composer require "predis/predis:${PREDIS_VERSION}" --dev --no-update; fi;
     - if [ "$PUBSUB_PREDIS_VERSION" != "" ]; then composer require "superbalist/php-pubsub-redis:${PUBSUB_PREDIS_VERSION}" --dev --no-update; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,24 @@ matrix:
         - php: 7.0
         - php: 5.6
         - php: 5.5
+          dist: trusty
         - php: 5.5
           env: SYMFONY_VERSION=2.7.*
+          dist: trusty
         - php: 5.5
           env: SYMFONY_VERSION=2.8.*
+          dist: trusty
         - php: 5.5
           env: SYMFONY_VERSION=3.4.*
+          dist: trusty
         - php: 7.1
           env: SYMFONY_VERSION=4.1.* PHPUNIT_VERSION=5.7.*
         - php: 5.5
           env: PREDIS_VERSION=1.0.*
+          dist: trusty
         - php: 5.5
           env: PREDIS_VERSION=1.1.*
+          dist: trusty
         - php: 5.6
           env: PUBSUB_PREDIS_VERSION=2.0.*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,8 @@ matrix:
           env: PREDIS_VERSION=1.1.*
         - php: 5.6
           env: PUBSUB_PREDIS_VERSION=2.0.*
-        - php: hhvm
-          sudo: required
-          dist: trusty
-          group: edge
 
 before_install:
-    - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then echo 'xdebug.enable = on' >> /etc/hhvm/php.ini; fi
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
 
 before_script:


### PR DESCRIPTION
* Correct run tests on PHP 5.5 in Travis CI
* HHVM not longer supported by Composer
* Fix memory limit error on run tests in Travis CI
* Test with PHP 7.3 in Travis CI