### PR TITLE
Correct branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "2.2-dev"
         }
     }
 }


### PR DESCRIPTION
Correct branch alias for master to `2.2-dev`