### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,12 @@
         "symfony/serializer": "~2.3|~3.0|~4.0",
         "predis/predis": "~1.0|~1.1",
         "php-amqplib/php-amqplib": "^2.9",
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.36",
         "scrutinizer/ocular": "~1.5",
-        "satooshi/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "branch-alias": {
             "dev-master": "2.2-dev"

--- a/tests/Aggregator/AggregateEventsRaiseInSelfTest.php
+++ b/tests/Aggregator/AggregateEventsRaiseInSelfTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Domain\Event\Tests\Aggregator;
 use GpsLab\Domain\Event\Event;
 use GpsLab\Domain\Event\Tests\Fixture\DemoAggregatorRaiseInSelf;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCreatedEvent;
+use PHPUnit\Framework\TestCase;
 
-class AggregateEventsRaiseInSelfTest extends \PHPUnit_Framework_TestCase
+class AggregateEventsRaiseInSelfTest extends TestCase
 {
     /**
      * @var DemoAggregatorRaiseInSelf

--- a/tests/Aggregator/AggregateEventsTest.php
+++ b/tests/Aggregator/AggregateEventsTest.php
@@ -11,8 +11,9 @@ namespace GpsLab\Domain\Event\Tests\Aggregator;
 
 use GpsLab\Domain\Event\Event;
 use GpsLab\Domain\Event\Tests\Fixture\DemoAggregator;
+use PHPUnit\Framework\TestCase;
 
-class AggregateEventsTest extends \PHPUnit_Framework_TestCase
+class AggregateEventsTest extends TestCase
 {
     /**
      * @var DemoAggregator

--- a/tests/Bus/ListenerLocatedEventBusTest.php
+++ b/tests/Bus/ListenerLocatedEventBusTest.php
@@ -16,8 +16,9 @@ use GpsLab\Domain\Event\Tests\Fixture\Listener\PurchaseOrderCompletedEventListen
 use GpsLab\Domain\Event\Tests\Fixture\Listener\PurchaseOrderCreatedEventListener;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCompletedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCreatedEvent;
+use PHPUnit\Framework\TestCase;
 
-class ListenerLocatedEventBusTest extends \PHPUnit_Framework_TestCase
+class ListenerLocatedEventBusTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|EventListenerLocator

--- a/tests/Bus/QueueEventBusTest.php
+++ b/tests/Bus/QueueEventBusTest.php
@@ -14,8 +14,9 @@ use GpsLab\Domain\Event\Bus\EventBus;
 use GpsLab\Domain\Event\Bus\QueueEventBus;
 use GpsLab\Domain\Event\Event;
 use GpsLab\Domain\Event\Queue\EventQueue;
+use PHPUnit\Framework\TestCase;
 
-class QueueEventBusTest extends \PHPUnit_Framework_TestCase
+class QueueEventBusTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|EventQueue

--- a/tests/Listener/Locator/ContainerEventListenerLocatorTest.php
+++ b/tests/Listener/Locator/ContainerEventListenerLocatorTest.php
@@ -16,8 +16,9 @@ use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCompletedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCreatedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\Subscriber\PurchaseOrderSubscriber;
 use Psr\Container\ContainerInterface;
+use PHPUnit\Framework\TestCase;
 
-class ContainerEventListenerLocatorTest extends \PHPUnit_Framework_TestCase
+class ContainerEventListenerLocatorTest extends TestCase
 {
     /**
      * @var ContainerEventListenerLocator

--- a/tests/Listener/Locator/DirectBindingEventListenerLocatorTest.php
+++ b/tests/Listener/Locator/DirectBindingEventListenerLocatorTest.php
@@ -16,8 +16,9 @@ use GpsLab\Domain\Event\Tests\Fixture\Listener\PurchaseOrderCreatedEventListener
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCompletedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCreatedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\Subscriber\PurchaseOrderSubscriber;
+use PHPUnit\Framework\TestCase;
 
-class DirectBindingEventListenerLocatorTest extends \PHPUnit_Framework_TestCase
+class DirectBindingEventListenerLocatorTest extends TestCase
 {
     /**
      * @var DirectBindingEventListenerLocator

--- a/tests/Listener/Locator/SymfonyContainerEventListenerLocatorTest.php
+++ b/tests/Listener/Locator/SymfonyContainerEventListenerLocatorTest.php
@@ -16,8 +16,9 @@ use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCompletedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCreatedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\Subscriber\PurchaseOrderSubscriber;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use PHPUnit\Framework\TestCase;
 
-class SymfonyContainerEventListenerLocatorTest extends \PHPUnit_Framework_TestCase
+class SymfonyContainerEventListenerLocatorTest extends TestCase
 {
     /**
      * @var SymfonyContainerEventListenerLocator

--- a/tests/Queue/Pull/MemoryPullEventQueueTest.php
+++ b/tests/Queue/Pull/MemoryPullEventQueueTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Domain\Event\Tests\Queue\Pull;
 use GpsLab\Domain\Event\Queue\Pull\MemoryPullEventQueue;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCompletedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCreatedEvent;
+use PHPUnit\Framework\TestCase;
 
-class MemoryPullEventQueueTest extends \PHPUnit_Framework_TestCase
+class MemoryPullEventQueueTest extends TestCase
 {
     /**
      * @var MemoryPullEventQueue

--- a/tests/Queue/Pull/PredisPullEventQueueTest.php
+++ b/tests/Queue/Pull/PredisPullEventQueueTest.php
@@ -16,8 +16,9 @@ use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCompletedEvent;
 use GpsLab\Domain\Event\Tests\Fixture\PurchaseOrderCreatedEvent;
 use Predis\ClientInterface;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 
-class PredisPullEventQueueTest extends \PHPUnit_Framework_TestCase
+class PredisPullEventQueueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|ClientInterface

--- a/tests/Queue/Serializer/SymfonySerializerTest.php
+++ b/tests/Queue/Serializer/SymfonySerializerTest.php
@@ -13,8 +13,9 @@ namespace GpsLab\Domain\Event\Tests\Queue\Serializer;
 use GpsLab\Domain\Event\Event;
 use GpsLab\Domain\Event\Queue\Serializer\SymfonySerializer;
 use Symfony\Component\Serializer\SerializerInterface;
+use PHPUnit\Framework\TestCase;
 
-class SymfonySerializerTest extends \PHPUnit_Framework_TestCase
+class SymfonySerializerTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|SerializerInterface

--- a/tests/Queue/Subscribe/AMQPSubscribeEventQueueTest.php
+++ b/tests/Queue/Subscribe/AMQPSubscribeEventQueueTest.php
@@ -16,8 +16,9 @@ use GpsLab\Domain\Event\Queue\Subscribe\AMQPSubscribeEventQueue;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Message\AMQPMessage;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 
-class AMQPSubscribeEventQueueTest extends \PHPUnit_Framework_TestCase
+class AMQPSubscribeEventQueueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Event

--- a/tests/Queue/Subscribe/ExecutingSubscribeEventQueueTest.php
+++ b/tests/Queue/Subscribe/ExecutingSubscribeEventQueueTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Domain\Event\Tests\Queue\Subscribe;
 
 use GpsLab\Domain\Event\Event;
 use GpsLab\Domain\Event\Queue\Subscribe\ExecutingSubscribeEventQueue;
+use PHPUnit\Framework\TestCase;
 
-class ExecutingSubscribeEventQueueTest extends \PHPUnit_Framework_TestCase
+class ExecutingSubscribeEventQueueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Event

--- a/tests/Queue/Subscribe/PredisSubscribeEventQueueTest.php
+++ b/tests/Queue/Subscribe/PredisSubscribeEventQueueTest.php
@@ -15,8 +15,9 @@ use GpsLab\Domain\Event\Queue\Serializer\Serializer;
 use GpsLab\Domain\Event\Queue\Subscribe\PredisSubscribeEventQueue;
 use Psr\Log\LoggerInterface;
 use Superbalist\PubSub\Redis\RedisPubSubAdapter;
+use PHPUnit\Framework\TestCase;
 
-class PredisSubscribeEventQueueTest extends \PHPUnit_Framework_TestCase
+class PredisSubscribeEventQueueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Event


### PR DESCRIPTION
# Changed log
- To be compatible with future PHPUnit version, using the `PHPUnit\Framework\TestCase` namespace.
- The `satooshi/php-coveralls` is deprecated, using the `php-coveralls/php-coveralls` instead.